### PR TITLE
Fix utilities that call api.nuget.org

### DIFF
--- a/data/tyzbit/hosts
+++ b/data/tyzbit/hosts
@@ -4,7 +4,7 @@
 127.0.0.1 compatexchange.cloudapp.net
 127.0.0.1 corp.sts.microsoft.com
 127.0.0.1 corpext.msitadfs.glbdns2.microsoft.com
-127.0.0.1 cs1.wpc.v0cdn.net
+# 127.0.0.1 cs1.wpc.v0cdn.net # breaks api.nuget.org
 127.0.0.1 diagnostics.support.microsoft.com
 127.0.0.1 feedback.search.microsoft.com
 127.0.0.1 feedback.windows.com


### PR DESCRIPTION
Namely, the new .NET Core binary for OSX.  You will be unable to execute any commands from the `dotnet` binary if this host is blocked.

I'm proposing simply commenting it out instead of removing it as not everyone will be using the `dotnet` package on OSX.

[More details.](https://github.com/dotnet/cli/issues/3746)
